### PR TITLE
正确隐藏window.navigator.webdriver

### DIFF
--- a/spiders/base.js
+++ b/spiders/base.js
@@ -90,7 +90,7 @@ class BaseSpider {
     this.editorSel = this.config.editorSel
 
     // 隐藏navigator
-    await this.page.evaluate(() => {
+    await this.page.evaluateOnNewDocument(() => {
       Object.defineProperty(navigator, 'webdriver', {
         get: () => false
       })


### PR DESCRIPTION
【问题描述】
Page.evaluate执行的js代码，在每次刷新页面、访问新的网址时会自动失效。

【解决方案】
需要使用Page. evaluateOnNewDocument让js代码在每次刷新、打开新的URL时都自动执行。

【修复措施】
修改spiders/base.js文件第93行，把`this.page.evaluate`修改为`this.page. evaluateOnNewDocument `

【相关文档】

[page.evaluateOnNewDocument(pageFunction[, ...args])](https://github.com/puppeteer/puppeteer/blob/v2.1.1/docs/api.md#pageevaluateonnewdocumentpagefunction-args)