### PR TITLE
在config中进行环境变量的覆盖

### DIFF
--- a/config.js
+++ b/config.js
@@ -1,10 +1,10 @@
 module.exports = {
   HOST: '0.0.0.0',
   PORT: 3000,
-  MONGO_HOST: 'localhost',
-  MONGO_PORT: '27017',
-  MONGO_DB: 'artipub',
-  MONGO_USERNAME: '',
-  MONGO_PASSWORD: '',
-  MONGO_AUTH_DB: 'admin'
+  MONGO_HOST: process.env.MONGO_HOST ? process.env.MONGO_HOST : 'localhost',
+  MONGO_PORT: process.env.MONGO_PORT ? process.env.MONGO_PORT : '27017',
+  MONGO_DB: process.env.MONGO_DB ? process.env.MONGO_DB : 'artipub',
+  MONGO_USERNAME: process.env.MONGO_USERNAME ? process.env.MONGO_USERNAME : '',
+  MONGO_PASSWORD: process.env.MONGO_PASSWORD ? process.env.MONGO_PASSWORD : '',
+  MONGO_AUTH_DB: process.env.MONGO_AUTH_DB ? process.env.MONGO_AUTH_DB : 'admin'
 }

--- a/server.js
+++ b/server.js
@@ -12,14 +12,8 @@ const logger = require('./logger')
 // express实例
 const app = express()
 
-// 环境变量覆盖
+// 环境变量
 console.log(process.env)
-if (process.env.MONGO_HOST) config.MONGO_HOST = process.env.MONGO_HOST
-if (process.env.MONGO_PORT) config.MONGO_PORT = process.env.MONGO_PORT
-if (process.env.MONGO_DB) config.MONGO_DB = process.env.MONGO_DB
-if (process.env.MONGO_USERNAME) config.MONGO_USERNAME = process.env.MONGO_USERNAME
-if (process.env.MONGO_PASSWORD) config.MONGO_PASSWORD = process.env.MONGO_PASSWORD
-if (process.env.MONGO_AUTH_DB) config.MONGO_AUTH_DB = process.env.MONGO_AUTH_DB
 
 // mongodb连接
 mongoose.Promise = global.Promise


### PR DESCRIPTION
在config中进行环境变量的覆盖，解决因exec.js早于server.js中环境变量覆盖的执行而导致的mongodb连接出错
Fixes #64 