### PR TITLE
将jelastic/nodejs:8.16.1-npm更新为jelastic/nodejs:8.17.0-npm，减小镜像体积

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,18 +1,18 @@
-FROM jelastic/nodejs:8.16.1-npm AS frontend
+FROM jelastic/nodejs:8.17.0-npm AS frontend
 
 WORKDIR /app
 ADD . /app
 RUN npm install
 RUN npm run build
 
-FROM jelastic/nodejs:8.16.1-npm
+FROM jelastic/nodejs:8.17.0-npm
 
 WORKDIR /app
 ADD . /app
 COPY --from=frontend /app/dist /frontend
 RUN cp ./backend/package.json .
 RUN npm install
-RUN yum install -y nginx
+RUN yum install -y nginx && yum clean all
 RUN cp /app/nginx/artipub.conf /etc/nginx/conf.d
 
 CMD /app/docker_init.sh

--- a/Dockerfile-local
+++ b/Dockerfile-local
@@ -1,18 +1,18 @@
-FROM jelastic/nodejs:8.16.1-npm AS frontend
+FROM jelastic/nodejs:8.17.0-npm AS frontend
 
 WORKDIR /app
 ADD . /app
 RUN npm install --registry=https://registry.npm.taobao.org
 RUN npm run build
 
-FROM jelastic/nodejs:8.16.1-npm
+FROM jelastic/nodejs:8.17.0-npm
 
 WORKDIR /app
 ADD . /app
 COPY --from=frontend /app/dist /frontend
 RUN cp ./backend/package.json .
 RUN npm install --registry=https://registry.npm.taobao.org
-RUN yum install -y nginx
+RUN yum install -y nginx && yum clean all
 RUN cp /app/nginx/artipub.conf /etc/nginx/conf.d
 
 CMD /app/docker_init.sh


### PR DESCRIPTION
将jelastic/nodejs:8.16.1-npm更新为jelastic/nodejs:8.17.0-npm，减小镜像体积
![docker](https://user-images.githubusercontent.com/19186382/102704292-89e58900-42b4-11eb-8a35-2f47338ebaad.png)
