### PR TITLE
修复掘金发布文章的标题问题以及脚注问题

### DIFF
--- a/spiders/juejin.js
+++ b/spiders/juejin.js
@@ -4,79 +4,82 @@ const constants = require('../constants')
 class JuejinSpider extends BaseSpider {
 
   async inputContent(article, editorSel) {
-    const footerContent = `<br><b>本篇文章由一文多发平台<a href="https://github.com/crawlab-team/artipub" target="_blank">ArtiPub</a>自动发布</b>`
+    const footerContent = `\n\n> 本篇文章由一文多发平台[ArtiPub](https://github.com/crawlab-team/artipub)自动发布`
     const content = article.content + footerContent
     const el = document.querySelector('.CodeMirror')
     el.CodeMirror.setValue(content)
   }
 
-    async afterGoToEditor() {
-        await this.page.goto(this.urls.editor)
-        await this.page.waitFor(5000)
-    }
+  async inputFooter(article, editorSel) {
+    // do nothing
+  }
+  async afterGoToEditor() {
+    await this.page.goto(this.urls.editor)
+    await this.page.waitFor(5000)
+  }
 
-    async afterInputEditor() {
-        // 点击发布文章
-        const elPubBtn = await this.page.$('.publish-popup')
-        await elPubBtn.click()
-        await this.page.waitFor(5000)
+  async afterInputEditor() {
+    // 点击发布文章
+    const elPubBtn = await this.page.$('.publish-popup')
+    await elPubBtn.click()
+    await this.page.waitFor(5000)
 
-        // 选择类别
-        await this.page.evaluate((task) => {
-            document.querySelectorAll('.category-list > .item').forEach(el => {
-                if (el.textContent === task.category) {
-                    el.click()
-                }
-            })
-        }, this.task)
-        await this.page.waitFor(5000)
+    // 选择类别
+    await this.page.evaluate((task) => {
+      document.querySelectorAll('.category-list > .item').forEach(el => {
+        if (el.textContent === task.category) {
+          el.click()
+        }
+      })
+    }, this.task)
+    await this.page.waitFor(5000)
 
-        // 选择标签
-        const elTagButton = await this.page.$('.add-btn-item')
-        await elTagButton.click()
-        const elTagInput = await this.page.$('.tag-input > input')
-        console.log(this.task.tag)
-        await elTagInput.type(this.task.tag)
-        await this.page.waitFor(5000)
-        await this.page.evaluate(() => {
-            document.querySelector('.suggested-tag-list > .tag:nth-child(1)').click()
-        })
-        await this.page.waitFor(5000)
-    }
+    // 选择标签
+    const elTagButton = await this.page.$('.add-btn-item')
+    await elTagButton.click()
+    const elTagInput = await this.page.$('.tag-input > input')
+    console.log(this.task.tag)
+    await elTagInput.type(this.task.tag)
+    await this.page.waitFor(5000)
+    await this.page.evaluate(() => {
+      document.querySelector('.suggested-tag-list > .tag:nth-child(1)').click()
+    })
+    await this.page.waitFor(5000)
+  }
 
-    async afterPublish() {
-        this.task.url = await this.page.evaluate(() => {
-            const el = document.querySelector('a.title')
-            return 'https://juejin.im' + el.getAttribute('href')
-        })
-        this.task.updateTs = new Date()
-        this.task.status = constants.status.FINISHED
-        await this.task.save()
-    }
+  async afterPublish() {
+    this.task.url = await this.page.evaluate(() => {
+      const el = document.querySelector('a.title')
+      return 'https://juejin.im' + el.getAttribute('href')
+    })
+    this.task.updateTs = new Date()
+    this.task.status = constants.status.FINISHED
+    await this.task.save()
+  }
 
-    async fetchStats() {
-        if (!this.task.url) return
-        await this.page.goto(this.task.url, { timeout: 60000 })
-        await this.page.waitFor(5000)
+  async fetchStats() {
+    if (!this.task.url) return
+    await this.page.goto(this.task.url, { timeout: 60000 })
+    await this.page.waitFor(5000)
 
-        const stats = await this.page.evaluate(() => {
-            const text = document.querySelector('body').innerText
-            const mRead = text.match(/阅读 (\d+)/)
-            const readNum = mRead ? Number(mRead[1]) : 0
-            const likeNum = Number(document.querySelector('.like-btn').getAttribute('badge'))
-            const commentNum = Number(document.querySelector('.comment-btn').getAttribute('badge'))
-            return {
-                readNum,
-                likeNum,
-                commentNum
-            }
-        })
-        this.task.readNum = stats.readNum
-        this.task.likeNum = stats.likeNum
-        this.task.commentNum = stats.commentNum
-        await this.task.save()
-        await this.page.waitFor(3000)
-    }
+    const stats = await this.page.evaluate(() => {
+      const text = document.querySelector('body').innerText
+      const mRead = text.match(/阅读 (\d+)/)
+      const readNum = mRead ? Number(mRead[1]) : 0
+      const likeNum = Number(document.querySelector('.like-btn').getAttribute('badge'))
+      const commentNum = Number(document.querySelector('.comment-btn').getAttribute('badge'))
+      return {
+        readNum,
+        likeNum,
+        commentNum
+      }
+    })
+    this.task.readNum = stats.readNum
+    this.task.likeNum = stats.likeNum
+    this.task.commentNum = stats.commentNum
+    await this.task.save()
+    await this.page.waitFor(3000)
+  }
 }
 
 module.exports = JuejinSpider


### PR DESCRIPTION
1. 在掘金发布文章时，标题后自动添加上脚注的文本
![掘金](https://user-images.githubusercontent.com/19186382/102706888-ce7f1d80-42d0-11eb-9439-843ba326a4d1.png)

2. 掘金默认为markdown编辑器，使用markdown的方式追加脚注比较稳妥。
